### PR TITLE
feat!: use native ESM

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -1,4 +1,0 @@
-module.exports = {
-  color: true,
-  'enable-source-maps': true,
-};

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,4 @@
+{
+  "color": true,
+  "enable-source-maps": true
+}

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ packages/
 .eslintignore            // eslint (linter) ignored directories/files
 .eslintrc                // eslint (linter) configuration
 .gitignore               // github's default node gitignore with customizations
-.mocharc.js              // mocha (test runner) configuration
+.mocharc.json            // mocha (test runner) configuration
 .prettierignore          // prettier (formatter) ignored directories/files
 .prettierrc              // prettier (formatter) configuration
 lerna.json               // lerna configuration (needed for deployment below)
@@ -67,7 +67,7 @@ package.json             // common dev deps and workspace-wide scripts
 README.md                // workspace-wide information. shown in github
 tsconfig.base.json       // common typescript configuration
 tsconfig.json            // solution-style root typescript configuration
-webpack.config.js        // root webpack configuration. inherited by app's webpack config
+webpack.config.cjs       // root webpack configuration. inherited by app's webpack config
 ```
 
 ### Styling solutions

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,6 @@
         "react-dom": "^18.1.0",
         "rimraf": "^3.0.2",
         "source-map-loader": "^3.0.1",
-        "ts-loader": "^9.3.0",
         "typescript": "~4.7.3",
         "webpack": "^5.73.0",
         "webpack-cli": "^4.9.2",
@@ -5620,25 +5619,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/ts-loader": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.3.0.tgz",
-      "integrity": "sha512-2kLLAdAD+FCKijvGKi9sS0OzoqxLCF3CxHpok7rVgCZ5UldRzH0TkbwG9XECKjBzHsAewntC5oDaI/FwKzEUog==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "enhanced-resolve": "^5.0.0",
-        "micromatch": "^4.0.0",
-        "semver": "^7.3.4"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "typescript": "*",
-        "webpack": "^5.0.0"
-      }
-    },
     "node_modules/tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
@@ -10458,18 +10438,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
-    },
-    "ts-loader": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.3.0.tgz",
-      "integrity": "sha512-2kLLAdAD+FCKijvGKi9sS0OzoqxLCF3CxHpok7rVgCZ5UldRzH0TkbwG9XECKjBzHsAewntC5oDaI/FwKzEUog==",
-      "dev": true,
-      "requires": {
-        "chalk": "^4.1.0",
-        "enhanced-resolve": "^5.0.0",
-        "micromatch": "^4.0.0",
-        "semver": "^7.3.4"
-      }
     },
     "tslib": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "sample-monorepo",
+  "type": "module",
   "workspaces": [
     "packages/*"
   ],
@@ -40,7 +41,6 @@
     "react-dom": "^18.1.0",
     "rimraf": "^3.0.2",
     "source-map-loader": "^3.0.1",
-    "ts-loader": "^9.3.0",
     "typescript": "~4.7.3",
     "webpack": "^5.73.0",
     "webpack-cli": "^4.9.2",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,7 +1,11 @@
 {
   "name": "@sample/app",
   "version": "1.0.0",
-  "main": "dist/index.js",
+  "type": "module",
+  "exports": {
+    ".": "./dist/index.js",
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "build": "npm run bundle:prod",
     "bundle:prod": "webpack --mode production",

--- a/packages/app/src/client-main.tsx
+++ b/packages/app/src/client-main.tsx
@@ -1,5 +1,5 @@
 import { createRoot, hydrateRoot } from 'react-dom/client';
-import { App } from './app';
+import { App } from './app.js';
 import 'sanitize.css';
 import 'sanitize.css/typography.css';
 

--- a/packages/app/src/index.ts
+++ b/packages/app/src/index.ts
@@ -1,1 +1,1 @@
-export * from './app';
+export * from './app.js';

--- a/packages/app/src/test/app.spec.tsx
+++ b/packages/app/src/test/app.spec.tsx
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { renderToString } from 'react-dom/server';
-import { App } from '../app';
+import { App } from '@sample/app';
 
 describe('<App />', () => {
   it('renders without throwing on the server', () => {

--- a/packages/app/webpack.config.cjs
+++ b/packages/app/webpack.config.cjs
@@ -2,13 +2,13 @@
 
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const rootWebpackConfig = require('../../webpack.config');
+const rootWebpackConfig = require('../../webpack.config.cjs');
 
 /** @type import('webpack').Configuration */
 module.exports = {
   ...rootWebpackConfig,
   entry: {
-    main: require.resolve('./src/client-main.tsx'),
+    main: require.resolve('./dist/client-main.js'),
   },
   output: {
     path: path.join(__dirname, 'dist/umd'),

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,7 +1,11 @@
 {
   "name": "@sample/components",
   "version": "1.0.0",
-  "main": "dist/index.js",
+  "type": "module",
+  "exports": {
+    ".": "./dist/index.js",
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "test": "mocha \"dist/test/**/*.spec.js\""
   },

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,1 +1,1 @@
-export * from './main';
+export * from './main.js';

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,11 @@
 {
   "name": "@sample/server",
   "version": "1.0.0",
-  "main": "dist/index.js",
+  "type": "module",
+  "exports": {
+    ".": "./dist/index.js",
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "test": "mocha \"dist/test/**/*.spec.js\"",
     "start": "node --enable-source-maps ./dist/server-main.js"

--- a/packages/server/src/http-server.tsx
+++ b/packages/server/src/http-server.tsx
@@ -1,9 +1,11 @@
-import path from 'path';
+import path from 'node:path';
+import { createRequire } from 'node:module';
 import express from 'express';
 import compression from 'compression';
 import ReactDOMServer from 'react-dom/server';
 import { App } from '@sample/app';
 
+const require = createRequire(import.meta.url);
 const appRootDirectory = path.dirname(require.resolve('@sample/app/package.json'));
 const appBundleDirectory = path.join(appRootDirectory, 'dist/umd');
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,1 +1,1 @@
-export * from './http-server';
+export * from './http-server.js';

--- a/packages/server/src/server-main.ts
+++ b/packages/server/src/server-main.ts
@@ -1,4 +1,4 @@
-import { createHttpServer } from './http-server';
+import { createHttpServer } from './http-server.js';
 
 const PORT = 3000;
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -11,8 +11,8 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2019",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    "lib": ["es2019", "dom"],                            /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    "target": "es2020",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "lib": ["es2020", "dom"],                            /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     "jsx": "react-jsx",                                  /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
     // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
@@ -25,9 +25,9 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "commonjs",                                /* Specify what module code is generated. */
+    "module": "node16",                                  /* Specify what module code is generated. */
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    "moduleResolution": "node",                          /* Specify how TypeScript looks up a file from a given module specifier. */
+    "moduleResolution": "node16",                        /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -14,19 +14,6 @@ module.exports = {
         loader: 'source-map-loader',
       },
       {
-        test: /\.tsx?$/,
-        loader: 'ts-loader',
-        options: {
-          projectReferences: true,
-          configFile: require.resolve('./tsconfig.json'),
-          compilerOptions: {
-            // build still catches these. avoid them during bunding time for a nicer dev experience.
-            noUnusedLocals: false,
-            noUnusedParameters: false,
-          },
-        },
-      },
-      {
         test: /\.css$/,
         use: [MiniCssExtractPlugin.loader, 'css-loader'],
       },
@@ -35,9 +22,6 @@ module.exports = {
         type: 'asset',
       },
     ],
-  },
-  resolve: {
-    extensions: ['.ts', '.tsx', '.js', '.json'],
   },
   plugins: [new MiniCssExtractPlugin()],
 };


### PR DESCRIPTION
- set packages to `"type": "module"`
- use `"exports"` instead of `"main"`. allow index and package.json imports.
- bump target (and lib) to es2020
- import App in test using self package reference
- use json for mocha config for better IDE completions and avoiding cjs/esm concerns
- remove `ts-loader`, as `webpack` cannot resolve relative files when the request ends with `.js` and the actual file (in src/) is `.ts/.tsx`. esm dist bundles well anyhow, as it allows better static analysis